### PR TITLE
Refactor tests

### DIFF
--- a/tests/Annotation/SymfonySentryAnnotationProviderIntegrationTest.php
+++ b/tests/Annotation/SymfonySentryAnnotationProviderIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Consistence\Sentry\SymfonyBundle\Annotation;
 use Consistence\Annotation\Annotation;
 use Consistence\Annotation\AnnotationField;
 use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\Assert;
 use ReflectionProperty;
 
 class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\TestCase
@@ -18,10 +19,10 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$property = new ReflectionProperty(Foo::class, 'noParams');
 
 		$annotation = $annotationProvider->getPropertyAnnotation($property, 'get');
-		$this->assertInstanceOf(Annotation::class, $annotation);
-		$this->assertSame('get', $annotation->getName());
-		$this->assertNull($annotation->getValue());
-		$this->assertEmpty($annotation->getFields());
+		Assert::assertInstanceOf(Annotation::class, $annotation);
+		Assert::assertSame('get', $annotation->getName());
+		Assert::assertNull($annotation->getValue());
+		Assert::assertEmpty($annotation->getFields());
 	}
 
 	public function testGetAnnotationWithFields(): void
@@ -30,17 +31,17 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$property = new ReflectionProperty(Foo::class, 'withFields');
 
 		$annotation = $annotationProvider->getPropertyAnnotation($property, 'get');
-		$this->assertInstanceOf(Annotation::class, $annotation);
-		$this->assertSame('get', $annotation->getName());
-		$this->assertNull($annotation->getValue());
+		Assert::assertInstanceOf(Annotation::class, $annotation);
+		Assert::assertSame('get', $annotation->getName());
+		Assert::assertNull($annotation->getValue());
 		$fields = $annotation->getFields();
-		$this->assertCount(2, $fields);
-		$this->assertInstanceOf(AnnotationField::class, $fields[0]);
-		$this->assertSame('name', $fields[0]->getName());
-		$this->assertSame('fooName', $fields[0]->getValue());
-		$this->assertInstanceOf(AnnotationField::class, $fields[1]);
-		$this->assertSame('visibility', $fields[1]->getName());
-		$this->assertSame('private', $fields[1]->getValue());
+		Assert::assertCount(2, $fields);
+		Assert::assertInstanceOf(AnnotationField::class, $fields[0]);
+		Assert::assertSame('name', $fields[0]->getName());
+		Assert::assertSame('fooName', $fields[0]->getValue());
+		Assert::assertInstanceOf(AnnotationField::class, $fields[1]);
+		Assert::assertSame('visibility', $fields[1]->getName());
+		Assert::assertSame('private', $fields[1]->getValue());
 	}
 
 	public function testGetAnnotationNotFound(): void
@@ -59,19 +60,19 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$property = new ReflectionProperty(Foo::class, 'multiple');
 
 		$annotations = $annotationProvider->getPropertyAnnotations($property, 'get');
-		$this->assertCount(2, $annotations);
-		$this->assertInstanceOf(Annotation::class, $annotations[0]);
-		$this->assertSame('get', $annotations[0]->getName());
-		$this->assertNull($annotations[0]->getValue());
-		$this->assertEmpty($annotations[0]->getFields());
-		$this->assertInstanceOf(Annotation::class, $annotations[1]);
-		$this->assertSame('get', $annotations[1]->getName());
-		$this->assertNull($annotations[1]->getValue());
+		Assert::assertCount(2, $annotations);
+		Assert::assertInstanceOf(Annotation::class, $annotations[0]);
+		Assert::assertSame('get', $annotations[0]->getName());
+		Assert::assertNull($annotations[0]->getValue());
+		Assert::assertEmpty($annotations[0]->getFields());
+		Assert::assertInstanceOf(Annotation::class, $annotations[1]);
+		Assert::assertSame('get', $annotations[1]->getName());
+		Assert::assertNull($annotations[1]->getValue());
 		$fields = $annotations[1]->getFields();
-		$this->assertCount(1, $fields);
-		$this->assertInstanceOf(AnnotationField::class, $fields[0]);
-		$this->assertSame('name', $fields[0]->getName());
-		$this->assertSame('fooName', $fields[0]->getValue());
+		Assert::assertCount(1, $fields);
+		Assert::assertInstanceOf(AnnotationField::class, $fields[0]);
+		Assert::assertSame('name', $fields[0]->getName());
+		Assert::assertSame('fooName', $fields[0]->getValue());
 	}
 
 	public function testGetAnnotationsNotFound(): void
@@ -79,7 +80,7 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$annotationProvider = $this->createAnnotationProvider();
 		$property = new ReflectionProperty(Foo::class, 'noParams');
 
-		$this->assertEmpty($annotationProvider->getPropertyAnnotations($property, 'foo'));
+		Assert::assertEmpty($annotationProvider->getPropertyAnnotations($property, 'foo'));
 	}
 
 	public function testUnstructuredAnnotation(): void
@@ -88,10 +89,10 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$property = new ReflectionProperty(Foo::class, 'noParams');
 
 		$annotation = $annotationProvider->getPropertyAnnotation($property, 'var');
-		$this->assertInstanceOf(Annotation::class, $annotation);
-		$this->assertSame('var', $annotation->getName());
-		$this->assertSame('string', $annotation->getValue());
-		$this->assertEmpty($annotation->getFields());
+		Assert::assertInstanceOf(Annotation::class, $annotation);
+		Assert::assertSame('var', $annotation->getName());
+		Assert::assertSame('string', $annotation->getValue());
+		Assert::assertEmpty($annotation->getFields());
 	}
 
 	private function createAnnotationProvider(): DoctrineSentryAnnotationProvider

--- a/tests/Annotation/SymfonySentryAnnotationProviderIntegrationTest.php
+++ b/tests/Annotation/SymfonySentryAnnotationProviderIntegrationTest.php
@@ -22,7 +22,7 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		Assert::assertInstanceOf(Annotation::class, $annotation);
 		Assert::assertSame('get', $annotation->getName());
 		Assert::assertNull($annotation->getValue());
-		Assert::assertEmpty($annotation->getFields());
+		Assert::assertCount(0, $annotation->getFields());
 	}
 
 	public function testGetAnnotationWithFields(): void
@@ -64,7 +64,7 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		Assert::assertInstanceOf(Annotation::class, $annotations[0]);
 		Assert::assertSame('get', $annotations[0]->getName());
 		Assert::assertNull($annotations[0]->getValue());
-		Assert::assertEmpty($annotations[0]->getFields());
+		Assert::assertCount(0, $annotations[0]->getFields());
 		Assert::assertInstanceOf(Annotation::class, $annotations[1]);
 		Assert::assertSame('get', $annotations[1]->getName());
 		Assert::assertNull($annotations[1]->getValue());
@@ -80,7 +80,7 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$annotationProvider = $this->createAnnotationProvider();
 		$property = new ReflectionProperty(Foo::class, 'noParams');
 
-		Assert::assertEmpty($annotationProvider->getPropertyAnnotations($property, 'foo'));
+		Assert::assertCount(0, $annotationProvider->getPropertyAnnotations($property, 'foo'));
 	}
 
 	public function testUnstructuredAnnotation(): void
@@ -92,7 +92,7 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		Assert::assertInstanceOf(Annotation::class, $annotation);
 		Assert::assertSame('var', $annotation->getName());
 		Assert::assertSame('string', $annotation->getValue());
-		Assert::assertEmpty($annotation->getFields());
+		Assert::assertCount(0, $annotation->getFields());
 	}
 
 	private function createAnnotationProvider(): DoctrineSentryAnnotationProvider

--- a/tests/Annotation/SymfonySentryAnnotationProviderIntegrationTest.php
+++ b/tests/Annotation/SymfonySentryAnnotationProviderIntegrationTest.php
@@ -49,9 +49,13 @@ class SymfonySentryAnnotationProviderIntegrationTest extends \PHPUnit\Framework\
 		$annotationProvider = $this->createAnnotationProvider();
 		$property = new ReflectionProperty(Foo::class, 'noParams');
 
-		$this->expectException(\Consistence\Annotation\AnnotationNotFoundException::class);
-
-		$annotationProvider->getPropertyAnnotation($property, 'foo');
+		try {
+			$annotationProvider->getPropertyAnnotation($property, 'foo');
+			Assert::fail('Exception expected');
+		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
+			Assert::assertSame($property, $e->getProperty());
+			Assert::assertSame('foo', $e->getAnnotationName());
+		}
 	}
 
 	public function testGetAnnotations(): void

--- a/tests/Annotation/VarAnnotationProviderIntegrationTest.php
+++ b/tests/Annotation/VarAnnotationProviderIntegrationTest.php
@@ -34,7 +34,7 @@ class VarAnnotationProviderIntegrationTest extends \PHPUnit\Framework\TestCase
 				'withoutVar'
 			), 'var');
 
-			Assert::fail();
+			Assert::fail('Exception expected');
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
 			Assert::assertSame(Foo::class, $e->getProperty()->getDeclaringClass()->getName());

--- a/tests/Annotation/VarAnnotationProviderIntegrationTest.php
+++ b/tests/Annotation/VarAnnotationProviderIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Annotation;
 
+use PHPUnit\Framework\Assert;
 use ReflectionProperty;
 
 class VarAnnotationProviderIntegrationTest extends \PHPUnit\Framework\TestCase
@@ -18,9 +19,9 @@ class VarAnnotationProviderIntegrationTest extends \PHPUnit\Framework\TestCase
 			'noParams'
 		), 'var');
 
-		$this->assertSame('var', $annotation->getName());
-		$this->assertSame('string', $annotation->getValue());
-		$this->assertEmpty($annotation->getFields());
+		Assert::assertSame('var', $annotation->getName());
+		Assert::assertSame('string', $annotation->getValue());
+		Assert::assertEmpty($annotation->getFields());
 	}
 
 	public function testVarAnnotationDoesNotExist(): void
@@ -33,12 +34,12 @@ class VarAnnotationProviderIntegrationTest extends \PHPUnit\Framework\TestCase
 				'withoutVar'
 			), 'var');
 
-			$this->fail();
+			Assert::fail();
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
-			$this->assertSame(Foo::class, $e->getProperty()->getDeclaringClass()->getName());
-			$this->assertSame('withoutVar', $e->getProperty()->getName());
-			$this->assertSame('var', $e->getAnnotationName());
+			Assert::assertSame(Foo::class, $e->getProperty()->getDeclaringClass()->getName());
+			Assert::assertSame('withoutVar', $e->getProperty()->getName());
+			Assert::assertSame('var', $e->getAnnotationName());
 		}
 	}
 

--- a/tests/Annotation/VarAnnotationProviderIntegrationTest.php
+++ b/tests/Annotation/VarAnnotationProviderIntegrationTest.php
@@ -21,7 +21,7 @@ class VarAnnotationProviderIntegrationTest extends \PHPUnit\Framework\TestCase
 
 		Assert::assertSame('var', $annotation->getName());
 		Assert::assertSame('string', $annotation->getValue());
-		Assert::assertEmpty($annotation->getFields());
+		Assert::assertCount(0, $annotation->getFields());
 	}
 
 	public function testVarAnnotationDoesNotExist(): void

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Annotation;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use ReflectionProperty;
@@ -12,26 +13,24 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return string[][]
+	 * @return string[][]|\Generator
 	 */
-	public function varAnnotationDataProvider(): array
+	public function varAnnotationDataProvider(): Generator
 	{
-		return [
-			['string'],
-			['integer'],
-			['null'],
-			['string|null'],
-			['int'],
-			['string|integer'],
-			['\Foo'],
-			['\Foo\Bar'],
-			['Foo'],
-			['\Foo|integer'],
-			['string[]'],
-			['\Foo[]'],
-			['Template<Foo>'],
-			['integer:string'],
-		];
+		yield ['string'];
+		yield ['integer'];
+		yield ['null'];
+		yield ['string|null'];
+		yield ['int'];
+		yield ['string|integer'];
+		yield ['\Foo'];
+		yield ['\Foo\Bar'];
+		yield ['Foo'];
+		yield ['\Foo|integer'];
+		yield ['string[]'];
+		yield ['\Foo[]'];
+		yield ['Template<Foo>'];
+		yield ['integer:string'];
 	}
 
 	/**

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Annotation;
 
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -51,7 +52,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 			->getMock();
 
 		$property
-			->expects($this->once())
+			->expects(self::once())
 			->method('getDocComment')
 			->willReturn($docComment);
 
@@ -59,9 +60,9 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 		$annotation = $varAnnotationProvider->getPropertyAnnotation($property, 'var');
 
-		$this->assertSame('var', $annotation->getName());
-		$this->assertSame($value, $annotation->getValue());
-		$this->assertEmpty($annotation->getFields());
+		Assert::assertSame('var', $annotation->getName());
+		Assert::assertSame($value, $annotation->getValue());
+		Assert::assertEmpty($annotation->getFields());
 	}
 
 	/**
@@ -79,7 +80,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 			->getMock();
 
 		$property
-			->expects($this->once())
+			->expects(self::once())
 			->method('getDocComment')
 			->willReturn($docComment);
 
@@ -87,9 +88,9 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 		$annotation = $varAnnotationProvider->getPropertyAnnotation($property, 'var');
 
-		$this->assertSame('var', $annotation->getName());
-		$this->assertSame($value, $annotation->getValue());
-		$this->assertEmpty($annotation->getFields());
+		Assert::assertSame('var', $annotation->getName());
+		Assert::assertSame($value, $annotation->getValue());
+		Assert::assertEmpty($annotation->getFields());
 	}
 
 	public function testVarAnnotationDoesNotExist(): void
@@ -105,17 +106,17 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 				->getMock();
 
 			$property
-				->expects($this->once())
+				->expects(self::once())
 				->method('getDocComment')
 				->willReturn($docComment);
 
 			$property
-				->expects($this->any())
+				->expects(self::any())
 				->method('getDeclaringClass')
 				->willReturn(new ReflectionClass(Foo::class));
 
 			$property
-				->expects($this->any())
+				->expects(self::any())
 				->method('getName')
 				->willReturn('test');
 
@@ -123,11 +124,11 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 			$varAnnotationProvider->getPropertyAnnotation($property, 'var');
 
-			$this->fail();
+			Assert::fail();
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
-			$this->assertSame($property, $e->getProperty());
-			$this->assertSame('var', $e->getAnnotationName());
+			Assert::assertSame($property, $e->getProperty());
+			Assert::assertSame('var', $e->getAnnotationName());
 		}
 	}
 
@@ -144,17 +145,17 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 				->getMock();
 
 			$property
-				->expects($this->once())
+				->expects(self::once())
 				->method('getDocComment')
 				->willReturn($docComment);
 
 			$property
-				->expects($this->any())
+				->expects(self::any())
 				->method('getDeclaringClass')
 				->willReturn(new ReflectionClass(Foo::class));
 
 			$property
-				->expects($this->any())
+				->expects(self::any())
 				->method('getName')
 				->willReturn('test');
 
@@ -162,11 +163,11 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 			$varAnnotationProvider->getPropertyAnnotation($property, 'var');
 
-			$this->fail();
+			Assert::fail();
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
-			$this->assertSame($property, $e->getProperty());
-			$this->assertSame('var', $e->getAnnotationName());
+			Assert::assertSame($property, $e->getProperty());
+			Assert::assertSame('var', $e->getAnnotationName());
 		}
 	}
 
@@ -179,12 +180,12 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 				->getMock();
 
 			$property
-				->expects($this->any())
+				->expects(self::any())
 				->method('getDeclaringClass')
 				->willReturn(new ReflectionClass(Foo::class));
 
 			$property
-				->expects($this->any())
+				->expects(self::any())
 				->method('getName')
 				->willReturn('test');
 
@@ -192,11 +193,11 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 			$varAnnotationProvider->getPropertyAnnotation($property, 'author');
 
-			$this->fail();
+			Assert::fail();
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
-			$this->assertSame($property, $e->getProperty());
-			$this->assertSame('author', $e->getAnnotationName());
+			Assert::assertSame($property, $e->getProperty());
+			Assert::assertSame('author', $e->getAnnotationName());
 		}
 	}
 
@@ -208,12 +209,12 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 			->getMock();
 
 		$property
-			->expects($this->never())
+			->expects(self::never())
 			->method('getDocComment');
 
 		$varAnnotationProvider = new VarAnnotationProvider();
 
-		$this->assertEmpty($varAnnotationProvider->getPropertyAnnotations($property, 'var'));
+		Assert::assertEmpty($varAnnotationProvider->getPropertyAnnotations($property, 'var'));
 	}
 
 }

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -62,7 +62,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 		Assert::assertSame('var', $annotation->getName());
 		Assert::assertSame($value, $annotation->getValue());
-		Assert::assertEmpty($annotation->getFields());
+		Assert::assertCount(0, $annotation->getFields());
 	}
 
 	/**
@@ -90,7 +90,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 		Assert::assertSame('var', $annotation->getName());
 		Assert::assertSame($value, $annotation->getValue());
-		Assert::assertEmpty($annotation->getFields());
+		Assert::assertCount(0, $annotation->getFields());
 	}
 
 	public function testVarAnnotationDoesNotExist(): void
@@ -214,7 +214,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 		$varAnnotationProvider = new VarAnnotationProvider();
 
-		Assert::assertEmpty($varAnnotationProvider->getPropertyAnnotations($property, 'var'));
+		Assert::assertCount(0, $varAnnotationProvider->getPropertyAnnotations($property, 'var'));
 	}
 
 }

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -17,46 +17,46 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function varAnnotationDataProvider(): Generator
 	{
-		yield [
+		yield 'string' => [
 			'value' => 'string',
 		];
-		yield [
+		yield 'integer' => [
 			'value' => 'integer',
 		];
-		yield [
+		yield 'null' => [
 			'value' => 'null',
 		];
-		yield [
+		yield 'string|null' => [
 			'value' => 'string|null',
 		];
-		yield [
+		yield 'int' => [
 			'value' => 'int',
 		];
-		yield [
+		yield 'string|integer' => [
 			'value' => 'string|integer',
 		];
-		yield [
+		yield '\Foo' => [
 			'value' => '\Foo',
 		];
-		yield [
+		yield '\Foo\Bar' => [
 			'value' => '\Foo\Bar',
 		];
-		yield [
+		yield 'Foo' => [
 			'value' => 'Foo',
 		];
-		yield [
+		yield '\Foo|integer' => [
 			'value' => '\Foo|integer',
 		];
-		yield [
+		yield 'string[]' => [
 			'value' => 'string[]',
 		];
-		yield [
+		yield '\Foo[]' => [
 			'value' => '\Foo[]',
 		];
-		yield [
+		yield 'Template<Foo>' => [
 			'value' => 'Template<Foo>',
 		];
-		yield [
+		yield 'integer:string' => [
 			'value' => 'integer:string',
 		];
 	}

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -14,7 +14,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return string[][]
 	 */
-	public function varAnnotationProvider(): array
+	public function varAnnotationDataProvider(): array
 	{
 		return [
 			['string'],
@@ -35,7 +35,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider varAnnotationProvider
+	 * @dataProvider varAnnotationDataProvider
 	 *
 	 * @param string $value
 	 */
@@ -65,7 +65,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider varAnnotationProvider
+	 * @dataProvider varAnnotationDataProvider
 	 *
 	 * @param string $value
 	 */

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -123,7 +123,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 			$varAnnotationProvider->getPropertyAnnotation($property, 'var');
 
-			Assert::fail();
+			Assert::fail('Exception expected');
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
 			Assert::assertSame($property, $e->getProperty());
@@ -162,7 +162,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 			$varAnnotationProvider->getPropertyAnnotation($property, 'var');
 
-			Assert::fail();
+			Assert::fail('Exception expected');
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
 			Assert::assertSame($property, $e->getProperty());
@@ -192,7 +192,7 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 
 			$varAnnotationProvider->getPropertyAnnotation($property, 'author');
 
-			Assert::fail();
+			Assert::fail('Exception expected');
 
 		} catch (\Consistence\Annotation\AnnotationNotFoundException $e) {
 			Assert::assertSame($property, $e->getProperty());

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -17,20 +17,48 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function varAnnotationDataProvider(): Generator
 	{
-		yield ['string'];
-		yield ['integer'];
-		yield ['null'];
-		yield ['string|null'];
-		yield ['int'];
-		yield ['string|integer'];
-		yield ['\Foo'];
-		yield ['\Foo\Bar'];
-		yield ['Foo'];
-		yield ['\Foo|integer'];
-		yield ['string[]'];
-		yield ['\Foo[]'];
-		yield ['Template<Foo>'];
-		yield ['integer:string'];
+		yield [
+			'string',
+		];
+		yield [
+			'integer',
+		];
+		yield [
+			'null',
+		];
+		yield [
+			'string|null',
+		];
+		yield [
+			'int',
+		];
+		yield [
+			'string|integer',
+		];
+		yield [
+			'\Foo',
+		];
+		yield [
+			'\Foo\Bar',
+		];
+		yield [
+			'Foo',
+		];
+		yield [
+			'\Foo|integer',
+		];
+		yield [
+			'string[]',
+		];
+		yield [
+			'\Foo[]',
+		];
+		yield [
+			'Template<Foo>',
+		];
+		yield [
+			'integer:string',
+		];
 	}
 
 	/**

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -26,7 +26,6 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 			['\Foo'],
 			['\Foo\Bar'],
 			['Foo'],
-			['Foo'],
 			['\Foo|integer'],
 			['string[]'],
 			['\Foo[]'],

--- a/tests/Annotation/VarAnnotationProviderTest.php
+++ b/tests/Annotation/VarAnnotationProviderTest.php
@@ -18,46 +18,46 @@ class VarAnnotationProviderTest extends \PHPUnit\Framework\TestCase
 	public function varAnnotationDataProvider(): Generator
 	{
 		yield [
-			'string',
+			'value' => 'string',
 		];
 		yield [
-			'integer',
+			'value' => 'integer',
 		];
 		yield [
-			'null',
+			'value' => 'null',
 		];
 		yield [
-			'string|null',
+			'value' => 'string|null',
 		];
 		yield [
-			'int',
+			'value' => 'int',
 		];
 		yield [
-			'string|integer',
+			'value' => 'string|integer',
 		];
 		yield [
-			'\Foo',
+			'value' => '\Foo',
 		];
 		yield [
-			'\Foo\Bar',
+			'value' => '\Foo\Bar',
 		];
 		yield [
-			'Foo',
+			'value' => 'Foo',
 		];
 		yield [
-			'\Foo|integer',
+			'value' => '\Foo|integer',
 		];
 		yield [
-			'string[]',
+			'value' => 'string[]',
 		];
 		yield [
-			'\Foo[]',
+			'value' => '\Foo[]',
 		];
 		yield [
-			'Template<Foo>',
+			'value' => 'Template<Foo>',
 		];
 		yield [
-			'integer:string',
+			'value' => 'integer:string',
 		];
 	}
 

--- a/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
@@ -55,19 +55,24 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	/**
 	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): Generator
+	public function configureContainerParameterDataProvider(): Generator
 	{
-		yield 'generated.target_dir' => [
+		yield 'default generated.target_dir' => [
+			'configuration' => [],
 			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
-			'parameterValue' => $this->getCacheDir() . '/sentry',
+			'expectedParameterValue' => $this->getCacheDir() . '/sentry',
 		];
-		yield 'generated.class_map_target_file' => [
+
+		yield 'default generated.class_map_target_file' => [
+			'configuration' => [],
 			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
-			'parameterValue' => $this->getCacheDir() . '/sentry/_classMap.php',
+			'expectedParameterValue' => $this->getCacheDir() . '/sentry/_classMap.php',
 		];
-		yield 'annotation.method_annotations_map' => [
+
+		yield 'default annotation.method_annotations_map' => [
+			'configuration' => [],
 			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
-			'parameterValue' => [
+			'expectedParameterValue' => [
 				Add::class => 'add',
 				Contains::class => 'contains',
 				Get::class => 'get',
@@ -75,32 +80,49 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 				Set::class => 'set',
 			],
 		];
+
+		yield 'configure generated.target_dir' => [
+			'configuration' => [
+				'generated_files_dir' => __DIR__,
+			],
+			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
+			'expectedParameterValue' => realpath(__DIR__),
+		];
+
+		yield 'configure annotation.method_annotations_map' => (static function (): array {
+			$methodAnnotationsMap = [
+				Get::class => 'get',
+				Set::class => 'set',
+			];
+
+			return [
+				'configuration' => [
+					'method_annotations_map' => $methodAnnotationsMap,
+				],
+				'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
+				'expectedParameterValue' => $methodAnnotationsMap,
+			];
+		})();
 	}
 
 	/**
-	 * @dataProvider defaultConfigurationValuesDataProvider
+	 * @dataProvider configureContainerParameterDataProvider
 	 *
+	 * @param mixed[][] $configuration
 	 * @param string $parameterName
-	 * @param mixed $parameterValue
+	 * @param mixed $expectedParameterValue
 	 */
-	public function testDefaultConfigurationValues(string $parameterName, $parameterValue): void
+	public function testConfigureContainerParameter(
+		array $configuration,
+		string $parameterName,
+		$expectedParameterValue
+	): void
 	{
-		$this->load();
-
-		$this->assertContainerBuilderHasParameter($parameterName, $parameterValue);
-
-		$this->compile();
-	}
-
-	public function testConfigureGeneratedFilesDir(): void
-	{
-		$this->load([
-			'generated_files_dir' => __DIR__,
-		]);
+		$this->load($configuration);
 
 		$this->assertContainerBuilderHasParameter(
-			ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
-			realpath(__DIR__)
+			$parameterName,
+			$expectedParameterValue
 		);
 
 		$this->compile();
@@ -125,24 +147,6 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 			realpath($dir) . '/_classMap.php'
 		);
 		Assert::assertFileExists($dir);
-
-		$this->compile();
-	}
-
-	public function testConfigureMethodAnnotationMap(): void
-	{
-		$methodAnnotationsMap = [
-			Get::class => 'get',
-			Set::class => 'set',
-		];
-		$this->load([
-			'method_annotations_map' => $methodAnnotationsMap,
-		]);
-
-		$this->assertContainerBuilderHasParameter(
-			ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
-			$methodAnnotationsMap
-		);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
@@ -9,6 +9,7 @@ use Consistence\Sentry\SymfonyBundle\Annotation\Contains;
 use Consistence\Sentry\SymfonyBundle\Annotation\Get;
 use Consistence\Sentry\SymfonyBundle\Annotation\Remove;
 use Consistence\Sentry\SymfonyBundle\Annotation\Set;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
@@ -52,28 +53,26 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): array
+	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		return [
+		yield [
+			ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
+			$this->getCacheDir() . '/sentry',
+		];
+		yield [
+			ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
+			$this->getCacheDir() . '/sentry/_classMap.php',
+		];
+		yield [
+			ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
 			[
-				ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
-				$this->getCacheDir() . '/sentry',
-			],
-			[
-				ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
-				$this->getCacheDir() . '/sentry/_classMap.php',
-			],
-			[
-				ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
-				[
-					Add::class => 'add',
-					Contains::class => 'contains',
-					Get::class => 'get',
-					Remove::class => 'remove',
-					Set::class => 'set',
-				],
+				Add::class => 'add',
+				Contains::class => 'contains',
+				Get::class => 'get',
+				Remove::class => 'remove',
+				Set::class => 'set',
 			],
 		];
 	}

--- a/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
@@ -9,6 +9,7 @@ use Consistence\Sentry\SymfonyBundle\Annotation\Contains;
 use Consistence\Sentry\SymfonyBundle\Annotation\Get;
 use Consistence\Sentry\SymfonyBundle\Annotation\Remove;
 use Consistence\Sentry\SymfonyBundle\Annotation\Set;
+use PHPUnit\Framework\Assert;
 
 class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
 {
@@ -110,7 +111,7 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	{
 		$dir = $this->getTempDir() . '/testConfigureGeneratedFilesDirNonExistingDirectoryCreatesDir';
 		@rmdir($dir);
-		$this->assertFileNotExists($dir);
+		Assert::assertFileNotExists($dir);
 
 		$this->load([
 			'generated_files_dir' => $dir,
@@ -124,7 +125,7 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 			ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
 			realpath($dir) . '/_classMap.php'
 		);
-		$this->assertFileExists($dir);
+		Assert::assertFileExists($dir);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
@@ -58,16 +58,16 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
 		yield [
-			ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
-			$this->getCacheDir() . '/sentry',
+			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
+			'parameterValue' => $this->getCacheDir() . '/sentry',
 		];
 		yield [
-			ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
-			$this->getCacheDir() . '/sentry/_classMap.php',
+			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
+			'parameterValue' => $this->getCacheDir() . '/sentry/_classMap.php',
 		];
 		yield [
-			ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
-			[
+			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
+			'parameterValue' => [
 				Add::class => 'add',
 				Contains::class => 'contains',
 				Get::class => 'get',

--- a/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
@@ -54,7 +54,7 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	/**
 	 * @return mixed[][]
 	 */
-	public function defaultConfigurationValuesProvider(): array
+	public function defaultConfigurationValuesDataProvider(): array
 	{
 		return [
 			[
@@ -79,7 +79,7 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	}
 
 	/**
-	 * @dataProvider defaultConfigurationValuesProvider
+	 * @dataProvider defaultConfigurationValuesDataProvider
 	 *
 	 * @param string $parameterName
 	 * @param mixed $parameterValue

--- a/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceSentryExtensionTest.php
@@ -57,15 +57,15 @@ class ConsistenceSentryExtensionTest extends \Matthias\SymfonyDependencyInjectio
 	 */
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		yield [
+		yield 'generated.target_dir' => [
 			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_TARGET_DIR,
 			'parameterValue' => $this->getCacheDir() . '/sentry',
 		];
-		yield [
+		yield 'generated.class_map_target_file' => [
 			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_GENERATED_CLASS_MAP_TARGET_FILE,
 			'parameterValue' => $this->getCacheDir() . '/sentry/_classMap.php',
 		];
-		yield [
+		yield 'annotation.method_annotations_map' => [
 			'parameterName' => ConsistenceSentryExtension::CONTAINER_PARAMETER_ANNOTATION_METHOD_ANNOTATIONS_MAP,
 			'parameterValue' => [
 				Add::class => 'add',

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
+use Closure;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Generator;
@@ -107,138 +108,136 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
+	 * @return mixed[][]|\Generator
 	 */
-	public function testSetInvalidCollectionType(Foo $foo): void
+	public function invalidArgumentTypeDataProvider(): Generator
 	{
-		$invalidValue = new DateTimeImmutable();
-		$eventDates = $invalidValue;
+		foreach ($this->fooDataProvider() as $caseName => $caseData) {
+			yield $caseName . ' - setEventDates() with invalid collection type' => (function () use ($caseData): array {
+				$invalidValue = new DateTimeImmutable();
 
-		try {
-			$foo->setEventDates($eventDates);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame(DateTimeImmutable::class, $e->getValueType());
-			Assert::assertSame('array', $e->getExpectedTypes());
+				return [
+					'callMethodCallback' => function () use ($caseData, $invalidValue): void {
+						$caseData['foo']->setEventDates($invalidValue);
+					},
+					'expectedInvalidValue' => $invalidValue,
+					'expectedInvalidValueType' => DateTimeImmutable::class,
+					'expectedExpectedTypes' => 'array',
+				];
+			})();
+
+			yield $caseName . ' - setEventDates() with invalid item type' => (function () use ($caseData): array {
+				$invalidValue = new stdClass();
+
+				return [
+					'callMethodCallback' => function () use ($caseData, $invalidValue): void {
+						$caseData['foo']->setEventDates([new DateTimeImmutable(), $invalidValue]);
+					},
+					'expectedInvalidValue' => $invalidValue,
+					'expectedInvalidValueType' => stdClass::class,
+					'expectedExpectedTypes' => DateTimeInterface::class,
+				];
+			})();
+
+			yield $caseName . ' - setEventDates() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->setEventDates([new DateTimeImmutable(), null]);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => DateTimeInterface::class,
+			];
+
+			yield $caseName . ' - addEventDate() with invalid item type' => (function () use ($caseData): array {
+				$invalidValue = new stdClass();
+
+				return [
+					'callMethodCallback' => function () use ($caseData, $invalidValue): void {
+						$caseData['foo']->addEventDate($invalidValue);
+					},
+					'expectedInvalidValue' => $invalidValue,
+					'expectedInvalidValueType' => stdClass::class,
+					'expectedExpectedTypes' => DateTimeInterface::class,
+				];
+			})();
+
+			yield $caseName . ' - addEventDate() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->addEventDate(null);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => DateTimeInterface::class,
+			];
+
+			yield $caseName . ' - containsEventDate() with invalid item type' => (function () use ($caseData): array {
+				$invalidValue = new stdClass();
+
+				return [
+					'callMethodCallback' => function () use ($caseData, $invalidValue): void {
+						$caseData['foo']->containsEventDate($invalidValue);
+					},
+					'expectedInvalidValue' => $invalidValue,
+					'expectedInvalidValueType' => stdClass::class,
+					'expectedExpectedTypes' => DateTimeInterface::class,
+				];
+			})();
+
+			yield $caseName . ' - containsEventDate() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->containsEventDate(null);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => DateTimeInterface::class,
+			];
+
+			yield $caseName . ' - removeEventDate() with invalid item type' => (function () use ($caseData): array {
+				$invalidValue = new stdClass();
+
+				return [
+					'callMethodCallback' => function () use ($caseData, $invalidValue): void {
+						$caseData['foo']->removeEventDate($invalidValue);
+					},
+					'expectedInvalidValue' => $invalidValue,
+					'expectedInvalidValueType' => stdClass::class,
+					'expectedExpectedTypes' => DateTimeInterface::class,
+				];
+			})();
+
+			yield $caseName . ' - removeEventDate() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->removeEventDate(null);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => DateTimeInterface::class,
+			];
 		}
 	}
 
 	/**
-	 * @dataProvider fooDataProvider
+	 * @dataProvider invalidArgumentTypeDataProvider
 	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
+	 * @param \Closure $callMethodCallback
+	 * @param mixed $expectedInvalidValue
+	 * @param string $expectedInvalidValueType
+	 * @param string $expectedExpectedTypes
 	 */
-	public function testSetInvalidItemType(Foo $foo): void
+	public function testCallMethodWithInvalidArgumentType(
+		Closure $callMethodCallback,
+		$expectedInvalidValue,
+		string $expectedInvalidValueType,
+		string $expectedExpectedTypes
+	): void
 	{
-		$invalidValue = new stdClass();
-		$eventDates = [new DateTimeImmutable(), $invalidValue];
-
 		try {
-			$foo->setEventDates($eventDates);
+			$callMethodCallback();
 			Assert::fail('Exception expected');
 		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame(stdClass::class, $e->getValueType());
-			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testSetNullValue(Foo $foo): void
-	{
-		$invalidValue = null;
-		$eventDates = [new DateTimeImmutable(), $invalidValue];
-
-		try {
-			$foo->setEventDates($eventDates);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('null', $e->getValueType());
-			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testAddInvalidItemType(Foo $foo): void
-	{
-		$invalidValue = new stdClass();
-
-		try {
-			$foo->addEventDate($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame(stdClass::class, $e->getValueType());
-			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testAddNull(Foo $foo): void
-	{
-		$invalidValue = null;
-
-		try {
-			$foo->addEventDate($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('null', $e->getValueType());
-			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testContainsInvalidItemType(Foo $foo): void
-	{
-		$invalidValue = new stdClass();
-
-		try {
-			$foo->containsEventDate($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame(stdClass::class, $e->getValueType());
-			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testRemoveInvalidItemType(Foo $foo): void
-	{
-		$invalidValue = new stdClass();
-
-		try {
-			$foo->removeEventDate($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame(stdClass::class, $e->getValueType());
-			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+			Assert::assertSame($expectedInvalidValue, $e->getValue());
+			Assert::assertSame($expectedInvalidValueType, $e->getValueType());
+			Assert::assertSame($expectedExpectedTypes, $e->getExpectedTypes());
 		}
 	}
 

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use PHPUnit\Framework\Assert;
 use stdClass;
 
@@ -109,10 +110,17 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetInvalidCollectionType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('array expected');
+		$invalidValue = new DateTimeImmutable();
+		$eventDates = $invalidValue;
 
-		$foo->setEventDates(new DateTimeImmutable());
+		try {
+			$foo->setEventDates($eventDates);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(DateTimeImmutable::class, $e->getValueType());
+			Assert::assertSame('array', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -122,10 +130,17 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeInterface expected');
+		$invalidValue = new stdClass();
+		$eventDates = [new DateTimeImmutable(), $invalidValue];
 
-		$foo->setEventDates([new DateTimeImmutable(), new stdClass()]);
+		try {
+			$foo->setEventDates($eventDates);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(stdClass::class, $e->getValueType());
+			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -135,10 +150,17 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetNullValue(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeInterface expected');
+		$invalidValue = null;
+		$eventDates = [new DateTimeImmutable(), $invalidValue];
 
-		$foo->setEventDates([new DateTimeImmutable(), null]);
+		try {
+			$foo->setEventDates($eventDates);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('null', $e->getValueType());
+			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -148,10 +170,16 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testAddInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeInterface expected');
+		$invalidValue = new stdClass();
 
-		$foo->addEventDate(new stdClass());
+		try {
+			$foo->addEventDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(stdClass::class, $e->getValueType());
+			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -161,10 +189,16 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testAddNull(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeInterface expected');
+		$invalidValue = null;
 
-		$foo->addEventDate(null);
+		try {
+			$foo->addEventDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('null', $e->getValueType());
+			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -174,10 +208,16 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testContainsInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeInterface expected');
+		$invalidValue = new stdClass();
 
-		$foo->containsEventDate(new stdClass());
+		try {
+			$foo->containsEventDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(stdClass::class, $e->getValueType());
+			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -187,10 +227,16 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testRemoveInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeInterface expected');
+		$invalidValue = new stdClass();
 
-		$foo->removeEventDate(new stdClass());
+		try {
+			$foo->removeEventDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(stdClass::class, $e->getValueType());
+			Assert::assertSame(DateTimeInterface::class, $e->getExpectedTypes());
+		}
 	}
 
 }

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -6,6 +6,7 @@ namespace Consistence\Sentry\SymfonyBundle\Type;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Generator;
 use PHPUnit\Framework\Assert;
 use stdClass;
 
@@ -13,16 +14,14 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
+	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]|\Generator
 	 */
-	public function fooDataProvider(): array
+	public function fooDataProvider(): Generator
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		return [
-			[new FooGenerated()],
-		];
+		yield [new FooGenerated()];
 	}
 
 	/**

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
 use DateTimeImmutable;
+use PHPUnit\Framework\Assert;
 use stdClass;
 
 class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
@@ -30,7 +31,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetEmpty(Foo $foo): void
 	{
-		$this->assertEmpty($foo->getEventDates());
+		Assert::assertEmpty($foo->getEventDates());
 	}
 
 	/**
@@ -45,7 +46,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 			new DateTimeImmutable('tomorrow'),
 		];
 		$foo->setEventDates($eventDates);
-		$this->assertEquals($eventDates, $foo->getEventDates());
+		Assert::assertEquals($eventDates, $foo->getEventDates());
 	}
 
 	/**
@@ -57,7 +58,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	{
 		$date = new DateTimeImmutable();
 		$foo->addEventDate($date);
-		$this->assertContains($date, $foo->getEventDates());
+		Assert::assertContains($date, $foo->getEventDates());
 	}
 
 	/**
@@ -75,9 +76,9 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 		];
 		$foo->setEventDates($dates);
 
-		$this->assertTrue($foo->containsEventDate($today));
-		$this->assertTrue($foo->containsEventDate($tomorrow));
-		$this->assertFalse($foo->containsEventDate(new DateTimeImmutable()));
+		Assert::assertTrue($foo->containsEventDate($today));
+		Assert::assertTrue($foo->containsEventDate($tomorrow));
+		Assert::assertFalse($foo->containsEventDate(new DateTimeImmutable()));
 	}
 
 	/**
@@ -97,8 +98,8 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 
 		$foo->removeEventDate($today);
 
-		$this->assertFalse($foo->containsEventDate($today));
-		$this->assertTrue($foo->containsEventDate($tomorrow));
+		Assert::assertFalse($foo->containsEventDate($today));
+		Assert::assertTrue($foo->containsEventDate($tomorrow));
 	}
 
 	/**

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -18,12 +18,14 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		$generator = new SentryDataGenerator();
-		$generator->generate('Foo');
+		yield (function (): array {
+			$generator = new SentryDataGenerator();
+			$generator->generate('Foo');
 
-		yield [
-			new FooGenerated(),
-		];
+			return [
+				new FooGenerated(),
+			];
+		})();
 	}
 
 	/**

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -18,7 +18,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		yield (function (): array {
+		yield 'instance of generated class' => (function (): array {
 			$generator = new SentryDataGenerator();
 			$generator->generate('Foo');
 

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -21,7 +21,9 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		yield [new FooGenerated()];
+		yield [
+			new FooGenerated(),
+		];
 	}
 
 	/**

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -31,7 +31,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetEmpty(Foo $foo): void
 	{
-		Assert::assertEmpty($foo->getEventDates());
+		Assert::assertCount(0, $foo->getEventDates());
 	}
 
 	/**

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -23,7 +23,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 			$generator->generate('Foo');
 
 			return [
-				new FooGenerated(),
+				'foo' => new FooGenerated(),
 			];
 		})();
 	}

--- a/tests/Type/CollectionOfObjectsIntegrationTest.php
+++ b/tests/Type/CollectionOfObjectsIntegrationTest.php
@@ -15,7 +15,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
 	 */
-	public function fooProvider(): array
+	public function fooDataProvider(): array
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
@@ -26,7 +26,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -36,7 +36,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -51,7 +51,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -63,7 +63,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -83,7 +83,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -104,7 +104,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -124,7 +124,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -144,7 +144,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -164,7 +164,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -183,7 +183,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -202,7 +202,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -221,7 +221,7 @@ class CollectionOfObjectsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -18,7 +18,9 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		yield [new FooGenerated()];
+		yield [
+			new FooGenerated(),
+		];
 	}
 
 	/**

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -4,22 +4,21 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
+	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]|\Generator
 	 */
-	public function fooDataProvider(): array
+	public function fooDataProvider(): Generator
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		return [
-			[new FooGenerated()],
-		];
+		yield [new FooGenerated()];
 	}
 
 	/**

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -29,7 +29,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetEmpty(Foo $foo): void
 	{
-		Assert::assertEmpty($foo->getAuthors());
+		Assert::assertCount(0, $foo->getAuthors());
 	}
 
 	/**

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -15,12 +15,14 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		$generator = new SentryDataGenerator();
-		$generator->generate('Foo');
+		yield (function (): array {
+			$generator = new SentryDataGenerator();
+			$generator->generate('Foo');
 
-		yield [
-			new FooGenerated(),
-		];
+			return [
+				new FooGenerated(),
+			];
+		})();
 	}
 
 	/**

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
+use Closure;
 use Generator;
 use PHPUnit\Framework\Assert;
 
@@ -99,138 +100,116 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
+	 * @return mixed[][]|\Generator
 	 */
-	public function testSetInvalidCollectionType(Foo $foo): void
+	public function invalidArgumentTypeDataProvider(): Generator
 	{
-		$invalidValue = 'Me';
-		$newValues = $invalidValue;
+		foreach ($this->fooDataProvider() as $caseName => $caseData) {
+			yield $caseName . ' - setAuthors() with invalid collection type' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->setAuthors('Me');
+				},
+				'expectedInvalidValue' => 'Me',
+				'expectedInvalidValueType' => 'string',
+				'expectedExpectedTypes' => 'array',
+			];
 
-		try {
-			$foo->setAuthors($newValues);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('string', $e->getValueType());
-			Assert::assertSame('array', $e->getExpectedTypes());
+			yield $caseName . ' - setAuthors() with invalid item type' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->setAuthors(['Me', 1]);
+				},
+				'expectedInvalidValue' => 1,
+				'expectedInvalidValueType' => 'int',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - setAuthors() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->setAuthors(['Me', null]);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - addAuthor() with invalid item type' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->addAuthor(1);
+				},
+				'expectedInvalidValue' => 1,
+				'expectedInvalidValueType' => 'int',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - addAuthor() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->addAuthor(null);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - containsAuthor() with invalid item type' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->containsAuthor(1);
+				},
+				'expectedInvalidValue' => 1,
+				'expectedInvalidValueType' => 'int',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - containsAuthor() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->containsAuthor(null);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - removeAuthor() with invalid item type' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->removeAuthor(1);
+				},
+				'expectedInvalidValue' => 1,
+				'expectedInvalidValueType' => 'int',
+				'expectedExpectedTypes' => 'string',
+			];
+
+			yield $caseName . ' - removeAuthor() with null value' => [
+				'callMethodCallback' => function () use ($caseData): void {
+					$caseData['foo']->removeAuthor(null);
+				},
+				'expectedInvalidValue' => null,
+				'expectedInvalidValueType' => 'null',
+				'expectedExpectedTypes' => 'string',
+			];
 		}
 	}
 
 	/**
-	 * @dataProvider fooDataProvider
+	 * @dataProvider invalidArgumentTypeDataProvider
 	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
+	 * @param \Closure $callMethodCallback
+	 * @param mixed $expectedInvalidValue
+	 * @param string $expectedInvalidValueType
+	 * @param string $expectedExpectedTypes
 	 */
-	public function testSetInvalidItemType(Foo $foo): void
+	public function testCallMethodWithInvalidArgumentType(
+		Closure $callMethodCallback,
+		$expectedInvalidValue,
+		string $expectedInvalidValueType,
+		string $expectedExpectedTypes
+	): void
 	{
-		$invalidValue = 1;
-		$newValues = ['Me', $invalidValue];
-
 		try {
-			$foo->setAuthors($newValues);
+			$callMethodCallback();
 			Assert::fail('Exception expected');
 		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('int', $e->getValueType());
-			Assert::assertSame('string', $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testSetNullValue(Foo $foo): void
-	{
-		$invalidValue = null;
-		$newValues = ['Me', $invalidValue];
-
-		try {
-			$foo->setAuthors($newValues);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('null', $e->getValueType());
-			Assert::assertSame('string', $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testAddInvalidItemType(Foo $foo): void
-	{
-		$invalidValue = 1;
-
-		try {
-			$foo->addAuthor($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('int', $e->getValueType());
-			Assert::assertSame('string', $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testAddNull(Foo $foo): void
-	{
-		$invalidValue = null;
-
-		try {
-			$foo->addAuthor($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('null', $e->getValueType());
-			Assert::assertSame('string', $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testContainsInvalidItemType(Foo $foo): void
-	{
-		$invalidValue = 1;
-
-		try {
-			$foo->containsAuthor($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('int', $e->getValueType());
-			Assert::assertSame('string', $e->getExpectedTypes());
-		}
-	}
-
-	/**
-	 * @dataProvider fooDataProvider
-	 *
-	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
-	 */
-	public function testRemoveInvalidItemType(Foo $foo): void
-	{
-		$invalidValue = 1;
-
-		try {
-			$foo->removeAuthor($invalidValue);
-			Assert::fail('Exception expected');
-		} catch (\Consistence\InvalidArgumentTypeException $e) {
-			Assert::assertSame($invalidValue, $e->getValue());
-			Assert::assertSame('int', $e->getValueType());
-			Assert::assertSame('string', $e->getExpectedTypes());
+			Assert::assertSame($expectedInvalidValue, $e->getValue());
+			Assert::assertSame($expectedInvalidValueType, $e->getValueType());
+			Assert::assertSame($expectedExpectedTypes, $e->getExpectedTypes());
 		}
 	}
 

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
+use PHPUnit\Framework\Assert;
+
 class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
@@ -27,7 +29,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetEmpty(Foo $foo): void
 	{
-		$this->assertEmpty($foo->getAuthors());
+		Assert::assertEmpty($foo->getAuthors());
 	}
 
 	/**
@@ -42,7 +44,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 			'Myself',
 		];
 		$foo->setAuthors($authors);
-		$this->assertEquals($authors, $foo->getAuthors());
+		Assert::assertEquals($authors, $foo->getAuthors());
 	}
 
 	/**
@@ -53,7 +55,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testAdd(Foo $foo): void
 	{
 		$foo->addAuthor('Irene');
-		$this->assertContains('Irene', $foo->getAuthors());
+		Assert::assertContains('Irene', $foo->getAuthors());
 	}
 
 	/**
@@ -69,9 +71,9 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 		];
 		$foo->setAuthors($authors);
 
-		$this->assertTrue($foo->containsAuthor('Me'));
-		$this->assertTrue($foo->containsAuthor('Myself'));
-		$this->assertFalse($foo->containsAuthor('Irene'));
+		Assert::assertTrue($foo->containsAuthor('Me'));
+		Assert::assertTrue($foo->containsAuthor('Myself'));
+		Assert::assertFalse($foo->containsAuthor('Irene'));
 	}
 
 	/**
@@ -89,8 +91,8 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 
 		$foo->removeAuthor('Me');
 
-		$this->assertFalse($foo->containsAuthor('Me'));
-		$this->assertTrue($foo->containsAuthor('Myself'));
+		Assert::assertFalse($foo->containsAuthor('Me'));
+		Assert::assertTrue($foo->containsAuthor('Myself'));
 	}
 
 	/**

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -12,7 +12,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
 	 */
-	public function fooProvider(): array
+	public function fooDataProvider(): array
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
@@ -23,7 +23,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -33,7 +33,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -48,7 +48,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -59,7 +59,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -77,7 +77,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -96,7 +96,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -116,7 +116,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -136,7 +136,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -156,7 +156,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -175,7 +175,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -194,7 +194,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -213,7 +213,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -102,10 +102,17 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetInvalidCollectionType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('array expected');
+		$invalidValue = 'Me';
+		$newValues = $invalidValue;
 
-		$foo->setAuthors('Me');
+		try {
+			$foo->setAuthors($newValues);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('string', $e->getValueType());
+			Assert::assertSame('array', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -115,10 +122,17 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = 1;
+		$newValues = ['Me', $invalidValue];
 
-		$foo->setAuthors(['Me', 1]);
+		try {
+			$foo->setAuthors($newValues);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -128,10 +142,17 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetNullValue(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = null;
+		$newValues = ['Me', $invalidValue];
 
-		$foo->setAuthors(['Me', null]);
+		try {
+			$foo->setAuthors($newValues);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('null', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -141,10 +162,16 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testAddInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = 1;
 
-		$foo->addAuthor(1);
+		try {
+			$foo->addAuthor($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -154,10 +181,16 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testAddNull(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = null;
 
-		$foo->addAuthor(null);
+		try {
+			$foo->addAuthor($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('null', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -167,10 +200,16 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testContainsInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = 1;
 
-		$foo->containsAuthor(1);
+		try {
+			$foo->containsAuthor($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -180,10 +219,16 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testRemoveInvalidItemType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = 1;
 
-		$foo->removeAuthor(1);
+		try {
+			$foo->removeAuthor($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 }

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -20,7 +20,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 			$generator->generate('Foo');
 
 			return [
-				new FooGenerated(),
+				'foo' => new FooGenerated(),
 			];
 		})();
 	}

--- a/tests/Type/CollectionOfStringsIntegrationTest.php
+++ b/tests/Type/CollectionOfStringsIntegrationTest.php
@@ -15,7 +15,7 @@ class CollectionOfStringsIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		yield (function (): array {
+		yield 'instance of generated class' => (function (): array {
 			$generator = new SentryDataGenerator();
 			$generator->generate('Foo');
 

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -14,7 +14,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
 	 */
-	public function fooProvider(): array
+	public function fooDataProvider(): array
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
@@ -25,7 +25,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -35,7 +35,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -47,7 +47,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -66,7 +66,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -85,7 +85,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -104,7 +104,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -123,7 +123,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -142,7 +142,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -20,7 +20,9 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		yield [new FooGenerated()];
+		yield [
+			new FooGenerated(),
+		];
 	}
 
 	/**

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -17,12 +17,14 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		$generator = new SentryDataGenerator();
-		$generator->generate('Foo');
+		yield (function (): array {
+			$generator = new SentryDataGenerator();
+			$generator->generate('Foo');
 
-		yield [
-			new FooGenerated(),
-		];
+			return [
+				new FooGenerated(),
+			];
+		})();
 	}
 
 	/**

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -6,6 +6,7 @@ namespace Consistence\Sentry\SymfonyBundle\Type;
 
 use DateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Assert;
 
 class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 {
@@ -30,7 +31,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetUninitialized(Foo $foo): void
 	{
-		$this->assertNull($foo->getPublishDate());
+		Assert::assertNull($foo->getPublishDate());
 	}
 
 	/**
@@ -42,7 +43,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	{
 		$publishDate = new DateTimeImmutable();
 		$foo->setPublishDate($publishDate);
-		$this->assertSame($publishDate, $foo->getPublishDate());
+		Assert::assertSame($publishDate, $foo->getPublishDate());
 	}
 
 	/**
@@ -119,11 +120,11 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	{
 		$immutable = new DateTimeImmutable();
 		$foo->setDateTimeInterface($immutable);
-		$this->assertSame($immutable, $foo->getDateTimeInterface());
+		Assert::assertSame($immutable, $foo->getDateTimeInterface());
 
 		$mutable = new DateTime();
 		$foo->setDateTimeInterface($mutable);
-		$this->assertSame($mutable, $foo->getDateTimeInterface());
+		Assert::assertSame($mutable, $foo->getDateTimeInterface());
 	}
 
 }

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -17,7 +17,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		yield (function (): array {
+		yield 'instance of generated class' => (function (): array {
 			$generator = new SentryDataGenerator();
 			$generator->generate('Foo');
 

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -6,22 +6,21 @@ namespace Consistence\Sentry\SymfonyBundle\Type;
 
 use DateTime;
 use DateTimeImmutable;
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
+	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]|\Generator
 	 */
-	public function fooDataProvider(): array
+	public function fooDataProvider(): Generator
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		return [
-			[new FooGenerated()],
-		];
+		yield [new FooGenerated()];
 	}
 
 	/**

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -22,7 +22,7 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 			$generator->generate('Foo');
 
 			return [
-				new FooGenerated(),
+				'foo' => new FooGenerated(),
 			];
 		})();
 	}

--- a/tests/Type/ObjectIntegrationTest.php
+++ b/tests/Type/ObjectIntegrationTest.php
@@ -53,10 +53,16 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetNullToNotNullable(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeImmutable expected');
+		$invalidValue = null;
 
-		$foo->setCreatedDate(null);
+		try {
+			$foo->setCreatedDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('null', $e->getValueType());
+			Assert::assertSame(DateTimeImmutable::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -66,10 +72,16 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetScalarType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeImmutable expected');
+		$invalidValue = 1;
 
-		$foo->setCreatedDate(1);
+		try {
+			$foo->setCreatedDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame(DateTimeImmutable::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -79,10 +91,16 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetInvalidType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeImmutable expected');
+		$invalidValue = new DateTime();
 
-		$foo->setCreatedDate(new DateTime());
+		try {
+			$foo->setCreatedDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(DateTime::class, $e->getValueType());
+			Assert::assertSame(DateTimeImmutable::class, $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -92,10 +110,16 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testNullableSetScalarType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeImmutable|null expected');
+		$invalidValue = 1;
 
-		$foo->setPublishDate(1);
+		try {
+			$foo->setPublishDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame(sprintf('%s|null', DateTimeImmutable::class), $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -105,10 +129,16 @@ class ObjectIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testNullableSetInvalidType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('DateTimeImmutable|null expected');
+		$invalidValue = new DateTime();
 
-		$foo->setPublishDate(new DateTime());
+		try {
+			$foo->setPublishDate($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame(DateTime::class, $e->getValueType());
+			Assert::assertSame(sprintf('%s|null', DateTimeImmutable::class), $e->getExpectedTypes());
+		}
 	}
 
 	/**

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
+use PHPUnit\Framework\Assert;
+
 class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
@@ -27,7 +29,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGet(Foo $foo): void
 	{
-		$this->assertSame('testName', $foo->getName());
+		Assert::assertSame('testName', $foo->getName());
 	}
 
 	/**
@@ -37,7 +39,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetUninitializedString(Foo $foo): void
 	{
-		$this->assertNull($foo->getDescription());
+		Assert::assertNull($foo->getDescription());
 	}
 
 	/**
@@ -48,7 +50,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testSet(Foo $foo): void
 	{
 		$foo->setName('fooBar');
-		$this->assertSame('fooBar', $foo->getName());
+		Assert::assertSame('fooBar', $foo->getName());
 	}
 
 	/**
@@ -71,7 +73,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testSetEmptyString(Foo $foo): void
 	{
 		$foo->setName('');
-		$this->assertSame('', $foo->getName());
+		Assert::assertSame('', $foo->getName());
 	}
 
 	/**
@@ -82,7 +84,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testSetStringZero(Foo $foo): void
 	{
 		$foo->setName('0');
-		$this->assertSame('0', $foo->getName());
+		Assert::assertSame('0', $foo->getName());
 	}
 
 	/**
@@ -93,7 +95,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testSetWhitespaceString(Foo $foo): void
 	{
 		$foo->setName('    ');
-		$this->assertSame('    ', $foo->getName());
+		Assert::assertSame('    ', $foo->getName());
 	}
 
 	/**
@@ -117,7 +119,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testNullableSetEmptyString(Foo $foo): void
 	{
 		$foo->setDescription('');
-		$this->assertSame('', $foo->getDescription());
+		Assert::assertSame('', $foo->getDescription());
 	}
 
 	/**
@@ -129,7 +131,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testNullableSetWhitespaceString(Foo $foo): void
 	{
 		$foo->setDescription('    ');
-		$this->assertSame('    ', $foo->getDescription());
+		Assert::assertSame('    ', $foo->getDescription());
 	}
 
 	/**
@@ -153,7 +155,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testCustomNameGetAndSet(Foo $foo): void
 	{
 		$foo->setMy('foo');
-		$this->assertSame('foo', $foo->getMy());
+		Assert::assertSame('foo', $foo->getMy());
 	}
 
 	/**
@@ -164,7 +166,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	public function testCallPrivateFromPublic(Foo $foo): void
 	{
 		$foo->setPublic('foo');
-		$this->assertSame('foo', $foo->getPrivate());
+		Assert::assertSame('foo', $foo->getPrivate());
 	}
 
 }

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -12,7 +12,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
 	 */
-	public function fooProvider(): array
+	public function fooDataProvider(): array
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
@@ -23,7 +23,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -33,7 +33,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -43,7 +43,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -54,7 +54,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -73,7 +73,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -84,7 +84,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -95,7 +95,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -106,7 +106,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -125,7 +125,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -136,7 +136,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 * @depends testGet
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
@@ -148,7 +148,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -167,7 +167,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */
@@ -178,7 +178,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider fooProvider
+	 * @dataProvider fooDataProvider
 	 *
 	 * @param \Consistence\Sentry\SymfonyBundle\Type\Foo $foo
 	 */

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -15,12 +15,14 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		$generator = new SentryDataGenerator();
-		$generator->generate('Foo');
+		yield (function (): array {
+			$generator = new SentryDataGenerator();
+			$generator->generate('Foo');
 
-		yield [
-			new FooGenerated(),
-		];
+			return [
+				new FooGenerated(),
+			];
+		})();
 	}
 
 	/**

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -4,22 +4,21 @@ declare(strict_types = 1);
 
 namespace Consistence\Sentry\SymfonyBundle\Type;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]
+	 * @return \Consistence\Sentry\SymfonyBundle\Type\Foo[][]|\Generator
 	 */
-	public function fooDataProvider(): array
+	public function fooDataProvider(): Generator
 	{
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		return [
-			[new FooGenerated()],
-		];
+		yield [new FooGenerated()];
 	}
 
 	/**

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -20,7 +20,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 			$generator->generate('Foo');
 
 			return [
-				new FooGenerated(),
+				'foo' => new FooGenerated(),
 			];
 		})();
 	}

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -60,9 +60,16 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetNullToNotNullable(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
+		$invalidValue = null;
 
-		$foo->setName(null);
+		try {
+			$foo->setName($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('null', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -105,10 +112,16 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testSetInvalidType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string expected');
+		$invalidValue = 1;
 
-		$foo->setName(1);
+		try {
+			$foo->setName($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame('string', $e->getExpectedTypes());
+		}
 	}
 
 	/**
@@ -141,10 +154,16 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testNullableSetInvalidType(Foo $foo): void
 	{
-		$this->expectException(\Consistence\InvalidArgumentTypeException::class);
-		$this->expectExceptionMessage('string|null expected');
+		$invalidValue = 1;
 
-		$foo->setDescription(1);
+		try {
+			$foo->setDescription($invalidValue);
+			Assert::fail('Exception expected');
+		} catch (\Consistence\InvalidArgumentTypeException $e) {
+			Assert::assertSame($invalidValue, $e->getValue());
+			Assert::assertSame('int', $e->getValueType());
+			Assert::assertSame('string|null', $e->getExpectedTypes());
+		}
 	}
 
 	/**

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -18,7 +18,9 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 		$generator = new SentryDataGenerator();
 		$generator->generate('Foo');
 
-		yield [new FooGenerated()];
+		yield [
+			new FooGenerated(),
+		];
 	}
 
 	/**

--- a/tests/Type/StringIntegrationTest.php
+++ b/tests/Type/StringIntegrationTest.php
@@ -15,7 +15,7 @@ class StringIntegrationTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function fooDataProvider(): Generator
 	{
-		yield (function (): array {
+		yield 'instance of generated class' => (function (): array {
 			$generator = new SentryDataGenerator();
 			$generator->generate('Foo');
 


### PR DESCRIPTION
- [x]  stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks